### PR TITLE
Set release tarball version from workflow input

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Upstream version (e.g. 6.14)'
+        description: 'Release version (e.g. 6.14, 6.14.1)'
         required: true
 
 jobs:
@@ -19,8 +19,9 @@ jobs:
           ref: master
       - name: Install build dependencies
         run: sudo apt-get update && sudo apt-get install -y autoconf automake xz-utils
-      - name: Build release tarball
+      - name: Set version and build release tarball
         run: |
+          sed -i "s/AC_INIT(\[byobu\], \[[^]]*\]/AC_INIT([byobu], [${{ inputs.version }}]/" configure.ac
           autoreconf -fi
           ./configure
           make dist


### PR DESCRIPTION
## Summary
- Patch `AC_INIT` version in `configure.ac` at build time using the workflow `version` input
- Allows releasing patch versions (e.g. 6.14.1) independently of upstream's `configure.ac`
- No changes committed to master -- the `sed` only runs in the workflow

## Test plan
- [ ] CI passes
- [ ] After merge, trigger a test release with a patch version to verify tarball naming